### PR TITLE
Improve main-class and module-version in module-info.class

### DIFF
--- a/atomos.runtime/pom.xml
+++ b/atomos.runtime/pom.xml
@@ -124,35 +124,12 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <archive>
+                        <manifest>
+                            <mainClass>org.apache.felix.atomos.launch.AtomosLauncher</mainClass>
+                        </manifest>
                         <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                 </configuration>
-            </plugin>
-            <plugin>
-                <!-- work around until maven-jar-plugin supports main-class attribute for module-info.class -->
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <configuration>
-                            <target>
-                                <exec executable="${java.home}/bin/jar" failonerror="true">
-                                    <arg value="--main-class"/>
-                                    <arg value="org.apache.felix.atomos.launch.AtomosLauncher"/>
-                                    <arg value="--module-version"/>
-                                    <arg value="0.0.1"/>
-                                    <arg value="--update"/>
-                                    <arg value="--file"/>
-                                    <arg value="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
-                                </exec>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -30,23 +30,18 @@
             <plugins>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-antrun-plugin</artifactId>
-                    <version>1.8</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <source>${maven.compiler.source}</source>
                         <target>${maven.compiler.target}</target>


### PR DESCRIPTION


update bundle maven-jar-plugin (main-class) https://issues.apache.org/jira/browse/MJAR-238
update bundle maven-compiler-plugin (version) https://issues.apache.org/jira/browse/MCOMPILER-322
remove ant plugin

Result:
// Compiled from module-info.java (version 11 : 55.0, no super bit)
 module org.apache.felix.atomos.runtime  {
  // Version: 0.0.1-SNAPSHOT

  requires java.base;
  requires transitive atomos.osgi.framework;
  requires protected osgi.annotation;
  requires protected jdk.unsupported;
  requires protected org.apache.felix.gogo.runtime;

  exports org.apache.felix.atomos.runtime;
  exports org.apache.felix.atomos.launch;

  uses org.osgi.framework.connect.ConnectFrameworkFactory
  uses org.osgi.framework.connect.ModuleConnector

  provides org.osgi.framework.connect.FrameworkUtilHelper with org.apache.felix.atomos.impl.runtime.base.AtomosFrameworkUtilHelper;
  provides org.osgi.framework.connect.ModuleConnector with org.apache.felix.atomos.impl.runtime.base.AtomosModuleConnector;

  Module packages:
    org.apache.felix.atomos.impl.runtime.content
    org.apache.felix.atomos.runtime
    org.apache.felix.atomos.impl.runtime.base
    org.apache.felix.atomos.launch
    org.apache.felix.atomos.impl.runtime.modules

  Module main class:
    org.apache.felix.atomos.launch.AtomosLauncher

}