### PR TITLE
mark equinox profile as activeByDefault

### DIFF
--- a/atomos.examples/atomos.examples.index/pom.xml
+++ b/atomos.examples/atomos.examples.index/pom.xml
@@ -22,7 +22,7 @@
     </repositories>
     <profiles>
         <profile>
-            <id>default</id>
+            <id>equinox</id>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.felix.atomos.osgi.frameworks.equinox</groupId>
@@ -33,16 +33,6 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-        </profile>
-        <profile>
-            <id>equinox</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.felix.atomos.osgi.frameworks.equinox</groupId>
-                    <artifactId>atomos.osgi.framework</artifactId>
-                    <version>${atomos.version}</version>
-                </dependency>
-            </dependencies>
         </profile>
         <profile>
             <id>felix</id>

--- a/atomos.examples/atomos.examples.jlink/pom.xml
+++ b/atomos.examples/atomos.examples.jlink/pom.xml
@@ -78,7 +78,7 @@
     </dependencies>
     <profiles>
         <profile>
-            <id>default</id>
+            <id>equinox</id>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.felix.atomos.osgi.frameworks.equinox</groupId>
@@ -89,16 +89,6 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-        </profile>
-        <profile>
-            <id>equinox</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.felix.atomos.osgi.frameworks.equinox</groupId>
-                    <artifactId>atomos.osgi.framework</artifactId>
-                    <version>${atomos.version}</version>
-                </dependency>
-            </dependencies>
         </profile>
         <profile>
             <id>felix</id>

--- a/atomos.runtime/pom.xml
+++ b/atomos.runtime/pom.xml
@@ -40,7 +40,7 @@
     </dependencies>
     <profiles>
         <profile>
-            <id>default</id>
+            <id>equinox</id>
             <dependencies>
                 <dependency>
                     <groupId>org.apache.felix.atomos.osgi.frameworks.equinox</groupId>
@@ -51,16 +51,6 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-        </profile>
-        <profile>
-            <id>equinox</id>
-            <dependencies>
-                <dependency>
-                    <groupId>org.apache.felix.atomos.osgi.frameworks.equinox</groupId>
-                    <artifactId>atomos.osgi.framework</artifactId>
-                    <version>${atomos.version}</version>
-                </dependency>
-            </dependencies>
         </profile>
         <profile>
             <id>felix</id>


### PR DESCRIPTION
It should be enough to mark one of the existing profiles as activeByDefault. So we can remove the profile with the name default