### PR TITLE
Only index duplicate resources

### DIFF
--- a/atomos.utils/atomos.utils.api/src/main/java/org/apache/felix/atomos/utils/api/plugin/JarPlugin.java
+++ b/atomos.utils/atomos.utils.api/src/main/java/org/apache/felix/atomos/utils/api/plugin/JarPlugin.java
@@ -21,6 +21,10 @@ import org.apache.felix.atomos.utils.api.Context;
 public interface JarPlugin<T> extends SubstratePlugin<T>
 {
 
+    default void initJar(JarFile jar, Context context, URLClassLoader classLoader)
+    {
+    }
+
     void doJar(JarFile jar, Context context, URLClassLoader classLoader);
 
     default void postJars(Context context)


### PR DESCRIPTION
The atomos bundles.index should list ALL
entries of each bundle, but the resources
stored in the atomos/ index directory
should only include the resources that have
duplicates