### PR TITLE
FELIX-6283 - Use correct path for including resources

### DIFF
--- a/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/index/IndexPlugin.java
+++ b/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/index/IndexPlugin.java
@@ -207,7 +207,14 @@ public class IndexPlugin implements JarPlugin<IndexPluginConfig>
                     bundleIndexLines.add(s.getVersion());
                     s.getFiles().forEach(f -> {
                         bundleIndexLines.add(f);
-                        resources.add(ATOMOS_BUNDLES_BASE_PATH + s.getId() + "/" + f);
+                        if (Boolean.FALSE == uniquePaths.get(f))
+                        {
+                            resources.add(ATOMOS_BUNDLES_BASE_PATH + s.getId() + "/" + f);
+                        }
+                        else
+                        {
+                            resources.add(f);
+                        }
                     });
                 }
             });


### PR DESCRIPTION
The Atomos index was updated to only index paths
that have duplicates.  All other resources are
expected to come from the root of the image
(or classpath).  This fix ensures the correct
resource path is used to include the unique paths
from the root of the image