### PR TITLE
FELIX-6283 - leave class resources out of image

### DIFF
--- a/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/index/IndexPlugin.java
+++ b/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/index/IndexPlugin.java
@@ -207,13 +207,17 @@ public class IndexPlugin implements JarPlugin<IndexPluginConfig>
                     bundleIndexLines.add(s.getVersion());
                     s.getFiles().forEach(f -> {
                         bundleIndexLines.add(f);
-                        if (Boolean.FALSE == uniquePaths.get(f))
+                        if (!isClass(f))
                         {
-                            resources.add(ATOMOS_BUNDLES_BASE_PATH + s.getId() + "/" + f);
-                        }
-                        else
-                        {
-                            resources.add(f);
+                            if (Boolean.FALSE == uniquePaths.get(f))
+                            {
+                                resources.add(
+                                    ATOMOS_BUNDLES_BASE_PATH + s.getId() + "/" + f);
+                            }
+                            else
+                            {
+                                resources.add(f);
+                            }
                         }
                     });
                 }


### PR DESCRIPTION
There should be no need to actually include the class resources in the
native image.  It only bloats the size of the image.