### PR TITLE
Use Bundle-ManifestVersion 2

### DIFF
--- a/atomos.runtime/src/main/java/org/apache/felix/atomos/impl/runtime/modules/ConnectContentModule.java
+++ b/atomos.runtime/src/main/java/org/apache/felix/atomos/impl/runtime/modules/ConnectContentModule.java
@@ -167,8 +167,9 @@ public class ConnectContentModule implements ConnectContent
         String bsn = result.get(Constants.BUNDLE_SYMBOLICNAME);
         if (bsn == null)
         {
-            // cannot use bundle manifest version 2 because we want to allow java.* exports
-            //result.put(Constants.BUNDLE_MANIFESTVERSION, "2");
+            // NOTE that we depend on the framework connect implementation to allow connect bundles
+            // to export java.* packages
+            result.put(Constants.BUNDLE_MANIFESTVERSION, "2");
             // set the symbolic name for the module; don't allow fragments to attach
             result.put(Constants.BUNDLE_SYMBOLICNAME,
                 symbolicName + "; " + Constants.FRAGMENT_ATTACHMENT_DIRECTIVE + ":="

--- a/atomos.tests/atomos.tests.modulepath.service/src/test/java/org/apache/felix/atomos/tests/modulepath/service/ModulepathLaunchTest.java
+++ b/atomos.tests/atomos.tests.modulepath.service/src/test/java/org/apache/felix/atomos/tests/modulepath/service/ModulepathLaunchTest.java
@@ -977,12 +977,6 @@ public class ModulepathLaunchTest
         assertEquals(Echo.class.getPackageName(), contractModule.getName(),
             "Wrong module name for contract module.");
 
-        // TODO Felix has some weird bug that causes this to fail
-        if (testFramework.getSymbolicName().startsWith("org.apache.felix.framework"))
-        {
-            return;
-        }
-
         // make sure the bundle wiring reflect the mapping correctly using the BSN
         Bundle testBundle = FrameworkUtil.getBundle(ModulepathLaunch.class);
         BundleWiring testWiring = testBundle.adapt(BundleWiring.class);

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
             <dependency>
                 <groupId>org.eclipse.platform</groupId>
                 <artifactId>org.eclipse.osgi</artifactId>
-                <version>3.16.0.tjwatson_osgiConnect13</version>
+                <version>3.16.0.tjwatson_osgiConnect14</version>
                 <exclusions>
                     <exclusion>
                         <groupId>*</groupId>


### PR DESCRIPTION
Atomos depends on the connect framework implementations to allow connect
bundles to export java.* packages.  Both Felix and Equinox Framework
implementations will allow this for connect bundles.  Prior to that
Atomos would use version 1 (no version) because exports of java.* were
allowed prior to version 2.

This causes issues because some frameworks ignore concepts introduced in
version 2 when version 1 is used (such as Require-Bundle).