### PR TITLE
Use --no-server to build native images

### DIFF
--- a/atomos.examples/atomos.examples.substrate.equinox/pom.xml
+++ b/atomos.examples/atomos.examples.substrate.equinox/pom.xml
@@ -151,6 +151,7 @@
                     <imageName>atomos</imageName>
                     <mainClass>org.apache.felix.atomos.launch.AtomosLauncher</mainClass>
                     <buildArgs>
+                        --no-server
                         --allow-incomplete-classpath
                         --no-fallback
                         --initialize-at-build-time=org.apache.felix.atomos.runtime,org.apache.felix.atomos.runtime.launch,org.apache.felix.atomos.impl,javax.servlet,org.apache.felix.service.command.Converter

--- a/atomos.examples/atomos.examples.substrate.felix/pom.xml
+++ b/atomos.examples/atomos.examples.substrate.felix/pom.xml
@@ -164,6 +164,7 @@
                     <imageName>atomos</imageName>
                     <mainClass>org.apache.felix.atomos.launch.AtomosLauncher</mainClass>
                     <buildArgs>
+                        --no-server
                         --allow-incomplete-classpath
                         --no-fallback
                         --initialize-at-build-time=org.apache.felix.atomos.runtime,org.apache.felix.atomos.launch,org.apache.felix.atomos.impl,javax.servlet,org.apache.felix.framework.util.Util,org.apache.felix.framework.util.SecureAction,org.apache.felix.framework.BundleWiringImpl,org.apache.felix.framework.BundleRevisionImpl,org.apache.felix.service.command.Converter


### PR DESCRIPTION
The native image server appears to be buggy and causes issues when
switching the framework from Equinox to Felix when building the
substrate examples.