### PR TITLE
Stop using parallel stream

### DIFF
--- a/atomos.examples/atomos.examples.jaxrs/pom.xml
+++ b/atomos.examples/atomos.examples.jaxrs/pom.xml
@@ -157,7 +157,6 @@
                             <additionalInitializeAtBuildTime>org.apache.cxf.bus.managers.DestinationFactoryManagerImpl</additionalInitializeAtBuildTime>
                             <additionalInitializeAtBuildTime>org.apache.cxf.bus.managers.ConduitInitiatorManagerImpl</additionalInitializeAtBuildTime>
                             <additionalInitializeAtBuildTime>org.apache.cxf.bus.managers.BindingFactoryManagerImpl</additionalInitializeAtBuildTime>
-                            <!-- <additionalInitializeAtBuildTime>org.apache.felix.atomos.impl.runtime.base</additionalInitializeAtBuildTime> -->
                         </additionalInitializeAtBuildTime>
                         <resourceConfigurationFiles>
                             <resourceConfigurationFile>additionalResourceConfig.json</resourceConfigurationFile>
@@ -175,7 +174,6 @@
                             <reflectionConfigurationFile>reflectConfig_jetty.json</reflectionConfigurationFile>
                             <reflectionConfigurationFile>reflectAgentConfig.json</reflectionConfigurationFile>
                         </reflectionConfigurationFiles>
-                        <!-- <mainClass>org.apache.felix.atomos.launch.AtomosLauncher</mainClass> -->
                     </nativeImage>
                 </configuration>
                 <executions>

--- a/atomos.maven/src/main/java/org/apache/felix/atomos/maven/LauncherBuilderUtil.java
+++ b/atomos.maven/src/main/java/org/apache/felix/atomos/maven/LauncherBuilderUtil.java
@@ -109,6 +109,7 @@ public class LauncherBuilderUtil
                     .anyMatch(s -> a.getArtifactId().matches(s));
             })//
             .map(a -> a.getFile().toPath())//
+            .sorted()//
             .collect(Collectors.toList());
 
         PathCollectorPluginConfig dc = new PathCollectorPluginConfig()

--- a/atomos.runtime/src/main/java/org/apache/felix/atomos/impl/runtime/base/AtomosRuntimeBase.java
+++ b/atomos.runtime/src/main/java/org/apache/felix/atomos/impl/runtime/base/AtomosRuntimeBase.java
@@ -32,6 +32,7 @@ import java.util.Deque;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -675,7 +676,7 @@ public abstract class AtomosRuntimeBase implements AtomosRuntime, SynchronousBun
 
         protected final Set<AtomosContentBase> findAtomosContents()
         {
-            Set<AtomosContentBase> bootBundles = new HashSet<>();
+            Set<AtomosContentBase> bootBundles = new LinkedHashSet<>();
 
             // first get the modules from the boot ModuleLayer (Java 9+ JPMS)
             findBootModuleLayerAtomosContents(bootBundles);

--- a/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/ContextImpl.java
+++ b/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/ContextImpl.java
@@ -198,7 +198,7 @@ public class ContextImpl implements Context
     @Override
     public Stream<Path> getFiles(FileType... fileType)
     {
-        return paths.entrySet().parallelStream().filter(
+        return paths.entrySet().stream().filter(
             e -> List.of(fileType).stream().filter(Objects::nonNull).anyMatch(
                 t -> t.equals(e.getValue()))).map(Entry::getKey);
     }

--- a/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/LauncherImpl.java
+++ b/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/LauncherImpl.java
@@ -133,7 +133,7 @@ public class LauncherImpl implements Launcher
             //      }
         }
 
-        List<ComponentDescription> cds = list.parallelStream().map(cmd -> {
+        List<ComponentDescription> cds = list.stream().map(cmd -> {
             cmd.validate();
             return new ComponentDescriptionImpl(cmd);
 
@@ -345,7 +345,7 @@ public class LauncherImpl implements Launcher
 
     private <T extends SubstratePlugin<?>> Stream<T> orderdPluginsBy(Class<T> clazz)
     {
-        return plugins.parallelStream()//
+        return plugins.stream()//
             .filter(clazz::isInstance)//
             .map(clazz::cast)//
             .sorted((p1, p2) -> p1.ranking(clazz) - p2.ranking(clazz));

--- a/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/collector/PathCollectorPlugin.java
+++ b/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/collector/PathCollectorPlugin.java
@@ -62,7 +62,7 @@ public class PathCollectorPlugin implements FileCollectorPlugin<PathCollectorPlu
             }
 
         };
-        config.paths().parallelStream().forEach(p -> {
+        config.paths().forEach(p -> {
             try
             {
                 Files.walkFileTree(p, v);

--- a/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/finaliser/shade/ShadePreHolder.java
+++ b/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/finaliser/shade/ShadePreHolder.java
@@ -65,7 +65,7 @@ public class ShadePreHolder
 
     List<JarFile> all()
     {
-        return source.entrySet().parallelStream().flatMap(
+        return source.entrySet().stream().flatMap(
             c -> c.getValue().stream()).collect(Collectors.toList());
     }
 
@@ -76,7 +76,7 @@ public class ShadePreHolder
 
     JarFile any()
     {
-        return source.entrySet().parallelStream().map(
+        return source.entrySet().stream().map(
             c -> c.getValue().stream().findAny()).findAny().get().get();
     }
 
@@ -92,7 +92,7 @@ public class ShadePreHolder
 
     long size()
     {
-        return source.entrySet().parallelStream().flatMap(
+        return source.entrySet().stream().flatMap(
             c -> c.getValue().stream()).count();
     }
 


### PR DESCRIPTION
The Atomos maven plugin was using parallel streams in several places.
Unfortunately many of the consumers called in the parallel streams are
not thread safe.  This can lead to unpredictable behavior.  For example,
randomly the plugin would omit a few bundles to include in the
processing.

This change also sorts the atomos index file to be in bundle symbolic
name order.  This allows for a consistent install order for images that
use the Atomos index.