### PR TITLE
Sort the bundles installed by default and exports from modules

### DIFF
--- a/atomos.runtime/src/main/java/org/apache/felix/atomos/impl/runtime/base/AtomosRuntimeBase.java
+++ b/atomos.runtime/src/main/java/org/apache/felix/atomos/impl/runtime/base/AtomosRuntimeBase.java
@@ -1593,7 +1593,7 @@ public abstract class AtomosRuntimeBase implements AtomosRuntime, SynchronousBun
         {
             debug("Installing Atomos content.");
             List<Bundle> bundles = new ArrayList<>();
-            for (AtomosContent atomosContent : atomosLayer.getAtomosContents())
+            atomosLayer.getAtomosContents().stream().sorted().forEach((atomosContent) -> //
             {
                 if (getBundle(atomosContent) == null)
                 {
@@ -1612,7 +1612,8 @@ public abstract class AtomosRuntimeBase implements AtomosRuntime, SynchronousBun
                             e.getMessage());
                     }
                 }
-            }
+            });
+
             if (startBundles)
             {
                 for (Bundle b : bundles)

--- a/atomos.runtime/src/main/java/org/apache/felix/atomos/impl/runtime/modules/ConnectContentModule.java
+++ b/atomos.runtime/src/main/java/org/apache/felix/atomos/impl/runtime/modules/ConnectContentModule.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.lang.module.ModuleDescriptor;
-import java.lang.module.ModuleDescriptor.Exports;
 import java.lang.module.ModuleDescriptor.Provides;
 import java.lang.module.ModuleDescriptor.Requires;
 import java.lang.module.ModuleReader;
@@ -181,7 +180,7 @@ public class ConnectContentModule implements ConnectContent
             // only do exports for non bundle modules
             // real OSGi bundles already have good export capabilities
             StringBuilder exportPackageHeader = new StringBuilder();
-            for (Exports exports : desc.exports())
+            desc.exports().stream().sorted().forEach((exports) ->
             {
                 if (exportPackageHeader.length() > 0)
                 {
@@ -189,7 +188,7 @@ public class ConnectContentModule implements ConnectContent
                 }
                 exportPackageHeader.append(exports.source());
                 // TODO map targets to x-friends directive?
-            }
+            });
             if (exportPackageHeader.length() > 0)
             {
                 result.put(Constants.EXPORT_PACKAGE, exportPackageHeader.toString());


### PR DESCRIPTION
To make it easier to observe the list of bundles installed by default
and the packages exported by modules this changes the order of both to
be sorted by name.