### PR TITLE
Add a headers provider hook

### DIFF
--- a/atomos.tests/atomos.tests.classpath.service/src/test/java/org/apache/felix/atomos/tests/classpath/service/test/ClasspathLaunchTest.java
+++ b/atomos.tests/atomos.tests.classpath.service/src/test/java/org/apache/felix/atomos/tests/classpath/service/test/ClasspathLaunchTest.java
@@ -203,7 +203,7 @@ public class ClasspathLaunchTest
     }
 
     @Test
-    void testBundleWithCustomHeader(@TempDir Path storage) throws BundleException
+    void testBundleWithCustomHeader(@TempDir Path storage) throws BundleException, InterruptedException
     {
         HeaderProvider headerProvider = (
             location, headers) -> {
@@ -223,6 +223,7 @@ public class ClasspathLaunchTest
         assertEquals(b.getLocation(), "atomos:" + b.getHeaders().get("X-TEST"));
 
         testFramework.stop();
+        testFramework.waitForStop(10000);
 
         // Bundles should already be installed, disable auto-install option
         // and check the provider is still used to provide the custom header

--- a/atomos.tests/atomos.tests.classpath.service/src/test/java/org/apache/felix/atomos/tests/classpath/service/test/ClasspathLaunchTest.java
+++ b/atomos.tests/atomos.tests.classpath.service/src/test/java/org/apache/felix/atomos/tests/classpath/service/test/ClasspathLaunchTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.felix.atomos.Atomos;
 import org.apache.felix.atomos.Atomos.HeaderProvider;
@@ -38,6 +39,7 @@ import org.apache.felix.atomos.AtomosLayer.LoaderType;
 import org.apache.felix.atomos.impl.base.AtomosCommands;
 import org.apache.felix.atomos.tests.testbundles.service.contract.Echo;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.osgi.framework.Bundle;
@@ -47,6 +49,7 @@ import org.osgi.framework.Constants;
 import org.osgi.framework.FrameworkUtil;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
 import org.osgi.framework.launch.Framework;
 import org.osgi.framework.namespace.PackageNamespace;
 import org.osgi.framework.wiring.BundleCapability;
@@ -174,6 +177,32 @@ public class ClasspathLaunchTest
     }
 
     @Test
+    void testUnmodifiableExistingHeaders(@TempDir Path storage) throws BundleException
+    {
+        AtomicBoolean fail = new AtomicBoolean(true);
+        HeaderProvider attemptModification = (location, headers) -> {
+            try
+            {
+                headers.put(Constants.BUNDLE_SYMBOLICNAME, "should.fail");
+                fail.set(true);
+            }
+            catch (UnsupportedOperationException e)
+            {
+                // expected
+                fail.set(false);
+            }
+            return Optional.empty();
+        };
+        testFramework = Atomos.newAtomos(attemptModification).newFramework(
+            Map.of(Constants.FRAMEWORK_STORAGE, storage.toFile().getAbsolutePath()));
+        testFramework.start();
+        if (fail.get())
+        {
+            Assertions.fail("Was able to modify the existing headers");
+        }
+    }
+
+    @Test
     void testBundleWithCustomHeader(@TempDir Path storage) throws BundleException
     {
         HeaderProvider headerProvider = (
@@ -208,6 +237,40 @@ public class ClasspathLaunchTest
         b = assertFindBundle(TESTBUNDLES_SERVICE_IMPL_A, runtime.getBootLayer(),
             runtime.getBootLayer(), true).getBundle();
         assertEquals(b.getLocation(), "atomos:" + b.getHeaders().get("X-TEST"));
+    }
+
+    @Test
+    void testHeaderProviderChangeBSN(@TempDir Path storage) throws BundleException
+    {
+        final String BSN_CONTRACT = "atomos.service.contract";
+        final String CHANGED_BSN = "changed.bsn";
+        HeaderProvider changeBSN = (location, headers) -> {
+            if (BSN_CONTRACT.equals(headers.get(Constants.BUNDLE_SYMBOLICNAME)))
+            {
+                headers = new HashMap<>(headers);
+                headers.put(Constants.BUNDLE_SYMBOLICNAME, CHANGED_BSN);
+                headers.put(Constants.BUNDLE_VERSION, "100");
+                return Optional.of(headers);
+            }
+            return Optional.empty();
+        };
+        Atomos atomos = Atomos.newAtomos(changeBSN);
+        testFramework = atomos.newFramework(
+            Map.of(Constants.FRAMEWORK_STORAGE, storage.toFile().getAbsolutePath()));
+        testFramework.start();
+
+        // make sure the contract names are correct
+        Bundle contractBundle = FrameworkUtil.getBundle(Echo.class);
+        assertEquals(CHANGED_BSN, contractBundle.getSymbolicName(),
+            "Wrong BSN for contract bundle.");
+        assertEquals(Version.valueOf("100"), contractBundle.getVersion());
+
+        atomos.getBootLayer().findAtomosContent(CHANGED_BSN).ifPresentOrElse((c) -> {
+            assertEquals(CHANGED_BSN, c.getSymbolicName());
+            assertEquals(Version.valueOf("100"), c.getVersion());
+        }, () -> {
+            fail("Could not find the content: " + CHANGED_BSN);
+        });
     }
 
     private AtomosContent assertFindBundle(String name, AtomosLayer layer,

--- a/atomos.tests/atomos.tests.index.bundles/src/test/java/org/apache/felix/atomos/tests/index/bundles/IndexLaunchTest.java
+++ b/atomos.tests/atomos.tests.index.bundles/src/test/java/org/apache/felix/atomos/tests/index/bundles/IndexLaunchTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,13 +30,17 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import org.apache.felix.atomos.Atomos;
+import org.apache.felix.atomos.Atomos.HeaderProvider;
 import org.apache.felix.atomos.AtomosContent;
 import org.apache.felix.atomos.AtomosLayer;
 import org.apache.felix.atomos.impl.base.AtomosBase;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.osgi.framework.Bundle;
@@ -45,6 +50,7 @@ import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
 import org.osgi.framework.InvalidSyntaxException;
 import org.osgi.framework.ServiceReference;
+import org.osgi.framework.Version;
 import org.osgi.framework.launch.Framework;
 import org.osgi.framework.wiring.BundleWiring;
 
@@ -330,26 +336,98 @@ public class IndexLaunchTest
     }
 
     @Test
+    void testUnmodifiableExistingHeaders(@TempDir Path storage) throws BundleException
+    {
+        AtomicBoolean fail = new AtomicBoolean(true);
+        HeaderProvider attemptModification = (location, headers) -> {
+            try
+            {
+                headers.put(Constants.BUNDLE_SYMBOLICNAME, "should.fail");
+                fail.set(true);
+            }
+            catch (UnsupportedOperationException e)
+            {
+                // expected
+                fail.set(false);
+            }
+            return Optional.empty();
+        };
+        testFramework = Atomos.newAtomos(attemptModification).newFramework(
+            Map.of(Constants.FRAMEWORK_STORAGE, storage.toFile().getAbsolutePath()));
+        testFramework.start();
+        if (fail.get())
+        {
+            Assertions.fail("Was able to modify the existing headers");
+        }
+    }
+
+    @Test
     void testBundleWithCustomHeader(@TempDir Path storage) throws BundleException
     {
-        testFramework = Atomos.newAtomos((location, headers) -> {
+        HeaderProvider provider = (location, headers) -> {
             headers = new HashMap<>(headers);
             headers.put("X-TEST", location);
             return Optional.of(headers);
-        }).newFramework(
+        };
+        testFramework = Atomos.newAtomos(provider).newFramework(
             Map.of(Constants.FRAMEWORK_STORAGE, storage.toFile().getAbsolutePath()));
         testFramework.start();
         BundleContext bc = testFramework.getBundleContext();
         assertNotNull(bc, "No context found.");
 
-        Atomos runtime = getRuntime(bc);
-        runtime.getBootLayer().getAtomosContents().forEach(c -> {
+        Consumer<AtomosContent> verifyHeader = c -> {
             if (c.getBundle().getBundleId() == 0)
             {
                 return;
             }
             String customHeader = c.getBundle().getHeaders(null).get("X-TEST");
             assertEquals(c.getAtomosLocation(), customHeader, "Wrong header value");
+        };
+
+        Atomos atomos = getRuntime(bc);
+        atomos.getBootLayer().getAtomosContents().forEach(verifyHeader);
+
+        testFramework.stop();
+
+        // Bundles should already be installed, disable auto-install option
+        // and check the provider is still used to provide the custom header
+        // for the already installed bundle from persistence
+        atomos = Atomos.newAtomos(Map.of(Atomos.ATOMOS_CONTENT_INSTALL, "false"),
+            provider);
+        testFramework = atomos.newFramework(
+                Map.of(Constants.FRAMEWORK_STORAGE, storage.toFile().getAbsolutePath()));
+        testFramework.start();
+        atomos.getBootLayer().getAtomosContents().forEach(verifyHeader);
+    }
+
+    @Test
+    void testHeaderProviderChangeBSN(@TempDir Path storage) throws BundleException
+    {
+        final String BSN_BUNDLE_1 = "bundle.1";
+        final String CHANGED_BSN = "changed.bsn";
+        HeaderProvider changeBSN = (location, headers) -> {
+            if (BSN_BUNDLE_1.equals(headers.get(Constants.BUNDLE_SYMBOLICNAME)))
+            {
+                headers = new HashMap<>(headers);
+                headers.put(Constants.BUNDLE_SYMBOLICNAME, CHANGED_BSN);
+                headers.put(Constants.BUNDLE_VERSION, "100");
+                return Optional.of(headers);
+            }
+            return Optional.empty();
+        };
+        Atomos atomos = Atomos.newAtomos(changeBSN);
+        testFramework = atomos.newFramework(
+            Map.of(Constants.FRAMEWORK_STORAGE, storage.toFile().getAbsolutePath()));
+        testFramework.start();
+
+        atomos.getBootLayer().findAtomosContent(CHANGED_BSN).ifPresentOrElse((c) -> {
+            assertEquals(CHANGED_BSN, c.getBundle().getSymbolicName(),
+                "Bundle symbolic name is incorrect.");
+            assertEquals(CHANGED_BSN, c.getSymbolicName(),
+                "Atomos content symbolic name is incorrect.");
+            assertEquals(Version.valueOf("100"), c.getVersion());
+        }, () -> {
+            fail("Could not find the content: " + CHANGED_BSN);
         });
     }
 }

--- a/atomos.tests/atomos.tests.index.bundles/src/test/java/org/apache/felix/atomos/tests/index/bundles/IndexLaunchTest.java
+++ b/atomos.tests/atomos.tests.index.bundles/src/test/java/org/apache/felix/atomos/tests/index/bundles/IndexLaunchTest.java
@@ -362,7 +362,7 @@ public class IndexLaunchTest
     }
 
     @Test
-    void testBundleWithCustomHeader(@TempDir Path storage) throws BundleException
+    void testBundleWithCustomHeader(@TempDir Path storage) throws BundleException, InterruptedException
     {
         HeaderProvider provider = (location, headers) -> {
             headers = new HashMap<>(headers);
@@ -388,6 +388,7 @@ public class IndexLaunchTest
         atomos.getBootLayer().getAtomosContents().forEach(verifyHeader);
 
         testFramework.stop();
+        testFramework.waitForStop(10000);
 
         // Bundles should already be installed, disable auto-install option
         // and check the provider is still used to provide the custom header

--- a/atomos.tests/atomos.tests.modulepath.service/src/test/java/org/apache/felix/atomos/tests/modulepath/service/ModulepathLaunchTest.java
+++ b/atomos.tests/atomos.tests.modulepath.service/src/test/java/org/apache/felix/atomos/tests/modulepath/service/ModulepathLaunchTest.java
@@ -1112,7 +1112,7 @@ public class ModulepathLaunchTest
     }
 
     @Test
-    void testModuleWithCustomerHeader(@TempDir Path storage) throws BundleException
+    void testModuleWithCustomerHeader(@TempDir Path storage) throws BundleException, InterruptedException
     {
         HeaderProvider provider = (location, headers) -> {
             headers = new HashMap<>(headers);
@@ -1133,6 +1133,7 @@ public class ModulepathLaunchTest
         assertEquals(contractBundle.getLocation(), "atomos:" + contractBundle.getHeaders().get("X-TEST"));
 
         testFramework.stop();
+        testFramework.waitForStop(10000);
 
         // Bundles should already be installed, disable auto-install option
         // and check the provider is still used to provide the custom header

--- a/atomos/pom.xml
+++ b/atomos/pom.xml
@@ -47,6 +47,22 @@
             </activation>
         </profile>
         <profile>
+            <id>unit-test</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.eclipse.platform</groupId>
+                    <artifactId>org.eclipse.osgi</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.apache.felix.atomos.equinox</groupId>
+                    <artifactId>osgi.core</artifactId>
+                    <version>8.0.0-SNAPSHOT</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>equinox</id>
             <dependencies>
                 <dependency>

--- a/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
@@ -271,7 +271,7 @@ public interface Atomos
 
     /**
      * Creates a new Atomos that can be used to create a new OSGi framework
-     * instance. Same as calling {@code newAtomos(Map)} with an empty
+     * instance. Same as calling {@code newAtomos(BiFunction,Map)} with an empty
      * configuration.
      *
      * @return a new Atomos.
@@ -294,7 +294,7 @@ public interface Atomos
      * Note that this {@code Atomos} must be used for creating a new
      * {@link ConnectFrameworkFactory#newFramework(Map, ModuleConnector)} instance to use
      * the layers added to this {@code Atomos}.
-     * 
+     *
      * @param configuration the properties to configure the new runtime
      * @return a new Atomos.
      */
@@ -318,6 +318,8 @@ public interface Atomos
      * the layers added to this {@code Atomos}.
      *
      * @param configuration the properties to configure the new runtime
+     * @param headerProvider a Bifunction that will be called with the location and the calculated headers for each module.
+     *                       The resulting map of invoking this funtion will be used as the headers of the module.
      * @return a new Atomos.
      */
     static Atomos newAtomos(Map<String, String> configuration, BiFunction<String, Map<String, String>, Optional<Map<String, String>>> headerProvider)

--- a/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
@@ -13,13 +13,15 @@
  */
 package org.apache.felix.atomos;
 
+import static org.apache.felix.atomos.impl.base.AtomosBase.NO_OP_HEADER_PROVIDER;
+
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.Optional;
+import java.util.ServiceLoader;
 import java.util.function.BiFunction;
 
 import org.apache.felix.atomos.AtomosLayer.LoaderType;
@@ -266,7 +268,7 @@ public interface Atomos
      */
     static Atomos newAtomos()
     {
-        return newAtomos((location, headers) -> Optional.empty());
+        return newAtomos(NO_OP_HEADER_PROVIDER);
     }
 
     /**
@@ -300,7 +302,7 @@ public interface Atomos
      */
     static Atomos newAtomos(Map<String, String> configuration)
     {
-        return newAtomos(configuration, (location, headers) -> Optional.empty());
+        return newAtomos(configuration, NO_OP_HEADER_PROVIDER);
     }
 
     /**
@@ -319,7 +321,7 @@ public interface Atomos
      *
      * @param configuration the properties to configure the new runtime
      * @param headerProvider a Bifunction that will be called with the location and the calculated headers for each module.
-     *                       The resulting map of invoking this funtion will be used as the headers of the module.
+     *                       The resulting map of invoking this function will be used as the headers of the module.
      * @return a new Atomos.
      */
     static Atomos newAtomos(Map<String, String> configuration, BiFunction<String, Map<String, String>, Optional<Map<String, String>>> headerProvider)

--- a/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
@@ -264,7 +264,7 @@ public interface Atomos
      * 
      * @return a new Atomos.
      */
-     static Atomos newAtomos()
+    static Atomos newAtomos()
     {
         return newAtomos((location, headers) -> Optional.empty());
     }

--- a/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
@@ -277,7 +277,7 @@ public interface Atomos
 
     /**
      * Creates a new Atomos that can be used to create a new OSGi framework
-     * instance. Same as calling {@code newAtomos(BiFunction,Map)} with an empty
+     * instance. Same as calling {@code newAtomos(Map,HeaderProvider)} with an empty
      * configuration.
      *
      * @param headerProvider the header provider function
@@ -290,7 +290,7 @@ public interface Atomos
 
     /**
      * Creates a new Atomos that can be used to create a new OSGi framework
-     * instance. Same as calling {@code newAtomos(BiFunction,Map)} with a
+     * instance. Same as calling {@code newAtomos(Map,HeaderProvider)} with a
      * no-op {@code headerProvider} function.
      *
      * @param configuration the properties to configure the new Atomos

--- a/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/Atomos.java
@@ -28,6 +28,7 @@ import org.apache.felix.atomos.AtomosLayer.LoaderType;
 import org.apache.felix.atomos.impl.base.AtomosBase;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.Constants;
+import org.osgi.framework.connect.ConnectContent;
 import org.osgi.framework.connect.ConnectFrameworkFactory;
 import org.osgi.framework.connect.ModuleConnector;
 import org.osgi.framework.launch.Framework;
@@ -285,19 +286,9 @@ public interface Atomos
 
     /**
      * Creates a new Atomos that can be used to create a new OSGi framework
-     * instance. If Atomos is running as a Java Module then this Atomos can
-     * be used to create additional layers by using the
-     * {@link AtomosLayer#addLayer(String, AtomosLayer.LoaderType, Path...)} method. If the additional layers are added
-     * before {@link ConnectFrameworkFactory#newFramework(Map, ModuleConnector)}  creating} and {@link Framework#init()
-     * initializing} the framework then the Atomos contents found in the added layers
-     * will be automatically installed and started according to the
-     * {@link #ATOMOS_CONTENT_INSTALL} and {@link #ATOMOS_CONTENT_START} options.
-     * <p>
-     * Note that this {@code Atomos} must be used for creating a new
-     * {@link ConnectFrameworkFactory#newFramework(Map, ModuleConnector)} instance to use
-     * the layers added to this {@code Atomos}.
+     * instance. Same as calling {@code newAtomos(BiFunction,Map)} with a
+     * no-op {@code headerProvider} function.
      *
-     * @param configuration the properties to configure the new runtime
      * @return a new Atomos.
      */
     static Atomos newAtomos(Map<String, String> configuration)
@@ -315,13 +306,20 @@ public interface Atomos
      * will be automatically installed and started according to the
      * {@link #ATOMOS_CONTENT_INSTALL} and {@link #ATOMOS_CONTENT_START} options.
      * <p>
-     * Note that this {@code Atomos} must be used for creating a new
-     * {@link ConnectFrameworkFactory#newFramework(Map, ModuleConnector)} instance to use
-     * the layers added to this {@code Atomos}.
+     * Note that this {@code Atomos} must be used for creating a new framework instance
+     * with the method {@link ConnectFrameworkFactory#newFramework(Map, ModuleConnector)} to use
+     * the layers added to this {@code Atomos} or the {@link #newFramework(Map)} method can
+     * be called on this {@code Atomos}.
+     * <p>
+     * The given headerProvider function maps each Atomos content
+     * {@link AtomosContent#getAtomosLocation() location}
+     * and calculated headers of the content to a new optional map of headers.
+     * The resulting map will be used as the headers for the {@link ConnectContent#getHeaders()}.
+     * If the function returns an empty optional then the original calculated
+     * headers will be used.
      *
      * @param configuration the properties to configure the new runtime
-     * @param headerProvider a Bifunction that will be called with the location and the calculated headers for each module.
-     *                       The resulting map of invoking this function will be used as the headers of the module.
+     * @param headerProvider a function that will be called with the location and the calculated headers for each module.
      * @return a new Atomos.
      */
     static Atomos newAtomos(Map<String, String> configuration, BiFunction<String, Map<String, String>, Optional<Map<String, String>>> headerProvider)

--- a/atomos/src/main/java/org/apache/felix/atomos/AtomosContent.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/AtomosContent.java
@@ -15,6 +15,7 @@ package org.apache.felix.atomos;
 
 import java.util.Optional;
 
+import org.osgi.annotation.versioning.ProviderType;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.framework.BundleException;
@@ -26,6 +27,7 @@ import org.osgi.framework.connect.ConnectContent;
  * by the Atomos runtime which can be installed as a connected
  * bundle into an OSGi Framework.
  */
+@ProviderType
 public interface AtomosContent extends Comparable<AtomosContent>
 {
 

--- a/atomos/src/main/java/org/apache/felix/atomos/AtomosLayer.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/AtomosLayer.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import org.osgi.annotation.versioning.ProviderType;
 import org.osgi.framework.BundleException;
 import org.osgi.framework.connect.ConnectFrameworkFactory;
 import org.osgi.framework.connect.ModuleConnector;
@@ -31,11 +32,13 @@ import org.osgi.framework.connect.ModuleConnector;
  * then be used to {@link AtomosContent#install(String) install } them as OSGi connected bundles into the
  * {@link ConnectFrameworkFactory#newFramework(Map, ModuleConnector)}  framework}.
  */
+@ProviderType
 public interface AtomosLayer
 {
     /**
      * The loader type used for the class loaders of an Atomos layer.
      */
+    @ProviderType
     enum LoaderType
     {
         /**

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosBase.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosBase.java
@@ -173,13 +173,13 @@ public abstract class AtomosBase implements Atomos, SynchronousBundleListener, F
     }
 
     private static Atomos loadRuntime(String runtimeClass,
-        Map<String, String> config, HeaderProvider manifestProvider)
+        Map<String, String> config, HeaderProvider headerProvider)
     {
         try
         {
             return (AtomosBase) Class.forName(
                 runtimeClass).getConstructor(Map.class, HeaderProvider.class).newInstance(
-                    config, manifestProvider);
+                    config, headerProvider);
         }
         catch (Exception e)
         {
@@ -1834,7 +1834,13 @@ public abstract class AtomosBase implements Atomos, SynchronousBundleListener, F
         String location,
         Map<String, String> existingHeaders)
     {
-        return holder.setHeaders(Optional.of(headerProvider.apply(location,
-            Collections.unmodifiableMap(existingHeaders)).orElse(existingHeaders)));
+        Optional<Map<String,String>> provided = headerProvider.apply(location,
+                Collections.unmodifiableMap(existingHeaders));
+        Map<String, String> headers = existingHeaders;
+        if (provided.isPresent())
+        {
+            headers = new HashMap<>(provided.get());
+        }
+        return holder.setHeaders(Optional.of(headers));
     }
 }

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosBase.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosBase.java
@@ -44,7 +44,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.BiFunction;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
@@ -102,7 +101,7 @@ public abstract class AtomosBase implements Atomos, SynchronousBundleListener, F
     public static final String ATOMOS_RUNTIME_MODULES_CLASS = "org.apache.felix.atomos.impl.modules.AtomosModules";
     public static final String ATOMOS_LIB_DIR = "atomos_lib";
     public static final String GRAAL_NATIVE_IMAGE_KIND = "org.graalvm.nativeimage.kind";
-    public static final BiFunction<String, Map<String, String>, Optional<Map<String, String>>> NO_OP_HEADER_PROVIDER = (
+    public static final HeaderProvider NO_OP_HEADER_PROVIDER = (
         l, h) -> Optional.empty();
 
     private final boolean DEBUG;
@@ -138,14 +137,15 @@ public abstract class AtomosBase implements Atomos, SynchronousBundleListener, F
 
     protected final AtomicLong nextLayerId = new AtomicLong(0);
 
-    protected final BiFunction<String, Map<String, String>, Optional<Map<String, String>>> headerProvider;
+    protected final HeaderProvider headerProvider;
 
     public static enum Index
     {
         IGNORE, FIRST
     }
 
-    public static Atomos newAtomos(Map<String, String> config, BiFunction<String, Map<String, String>, Optional<Map<String, String>>> headerProvider)
+    public static Atomos newAtomos(Map<String, String> config,
+        HeaderProvider headerProvider)
     {
         String runtimeClass = config.get(ATOMOS_CLASS_PROP);
         if (runtimeClass != null)
@@ -172,12 +172,13 @@ public abstract class AtomosBase implements Atomos, SynchronousBundleListener, F
     }
 
     private static Atomos loadRuntime(String runtimeClass,
-        Map<String, String> config, BiFunction<String, Map<String, String>, Optional<Map<String, String>>> manifestProvider)
+        Map<String, String> config, HeaderProvider manifestProvider)
     {
         try
         {
             return (AtomosBase) Class.forName(
-                runtimeClass).getConstructor(Map.class, BiFunction.class).newInstance(config, manifestProvider);
+                runtimeClass).getConstructor(Map.class, HeaderProvider.class).newInstance(
+                    config, manifestProvider);
         }
         catch (Exception e)
         {
@@ -200,7 +201,7 @@ public abstract class AtomosBase implements Atomos, SynchronousBundleListener, F
         return new File(libDirProp, ATOMOS_LIB_DIR);
     }
 
-    protected AtomosBase(Map<String, String> config, BiFunction<String, Map<String, String>, Optional<Map<String, String>>> headerProvider)
+    protected AtomosBase(Map<String, String> config, HeaderProvider headerProvider)
     {
         saveConfig(config);
         this.headerProvider = headerProvider;

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosClassPath.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosClassPath.java
@@ -22,6 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.Optional;
 
 import org.apache.felix.atomos.AtomosContent;
 import org.apache.felix.atomos.AtomosLayer;
@@ -34,9 +36,9 @@ public class AtomosClassPath extends AtomosBase
 
     private final AtomosLayer bootLayer = createBootLayer();
 
-    public AtomosClassPath(Map<String, String> config)
+    public AtomosClassPath(Map<String, String> config, BiFunction<String, Map<String, String>, Optional<Map<String, String>>> headerProvider)
     {
-        super(config);
+        super(config, headerProvider);
     }
 
     private AtomosLayer createBootLayer()

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosClassPath.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosClassPath.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.function.BiFunction;
-import java.util.Optional;
 
 import org.apache.felix.atomos.AtomosContent;
 import org.apache.felix.atomos.AtomosLayer;
@@ -36,7 +34,7 @@ public class AtomosClassPath extends AtomosBase
 
     private final AtomosLayer bootLayer = createBootLayer();
 
-    public AtomosClassPath(Map<String, String> config, BiFunction<String, Map<String, String>, Optional<Map<String, String>>> headerProvider)
+    public AtomosClassPath(Map<String, String> config, HeaderProvider headerProvider)
     {
         super(config, headerProvider);
     }

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentCloseableJar.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentCloseableJar.java
@@ -17,6 +17,8 @@ import static org.apache.felix.atomos.impl.base.AtomosBase.sneakyThrow;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.zip.ZipFile;
@@ -81,9 +83,9 @@ public class ConnectContentCloseableJar extends ConnectContentJar
 
     }
 
-    public ConnectContentCloseableJar(String fileName, Supplier<File> rootSupplier)
+    public ConnectContentCloseableJar(String fileName, Supplier<File> rootSupplier, Supplier<Optional<Map<String, String>>> headers)
     {
         super(new ZipFileHolder(fileName, rootSupplier),
-            z -> ((ZipFileHolder) z).accept(z));
+            z -> ((ZipFileHolder) z).accept(z), headers);
     }
 }

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentFile.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentFile.java
@@ -21,6 +21,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import org.osgi.framework.connect.ConnectContent;
@@ -77,9 +78,12 @@ public class ConnectContentFile implements ConnectContent
 
     final File root;
 
-    public ConnectContentFile(File root)
+    final Supplier<Optional<Map<String, String>>> headers;
+
+    public ConnectContentFile(File root, Supplier<Optional<Map<String, String>>> headers)
     {
         this.root = root;
+        this.headers = headers;
     }
 
     @Override
@@ -152,7 +156,7 @@ public class ConnectContentFile implements ConnectContent
     @Override
     public Optional<Map<String, String>> getHeaders()
     {
-        return Optional.empty();
+        return headers.get();
     }
 
 }

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentIndexed.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentIndexed.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.osgi.framework.connect.ConnectContent;
 
@@ -80,17 +81,19 @@ public class ConnectContentIndexed implements ConnectContent
 
     private final String index;
     private final Set<String> entries;
+    final Supplier<Optional<Map<String, String>>> headers;
 
-    public ConnectContentIndexed(String index, List<String> entries)
+    public ConnectContentIndexed(String index, List<String> entries, Supplier<Optional<Map<String, String>>> headers)
     {
         this.index = index;
         this.entries = Collections.unmodifiableSet(new LinkedHashSet<>(entries));
+        this.headers = headers;
     }
 
     @Override
     public Optional<Map<String, String>> getHeaders()
     {
-        return Optional.empty();
+        return headers.get();
     }
 
     @Override

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentJar.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentJar.java
@@ -48,10 +48,7 @@ public class ConnectContentJar implements ConnectContent
     @Override
     public void close() throws IOException
     {
-        if (closer != null)
-        {
-            closer.accept(zipSupplier);
-        }
+        closer.accept(zipSupplier);
     }
 
     @Override

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentJar.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/content/ConnectContentJar.java
@@ -30,11 +30,13 @@ public class ConnectContentJar implements ConnectContent
 {
     final Supplier<ZipFile> zipSupplier;
     final Consumer<Supplier<ZipFile>> closer;
+    final Supplier<Optional<Map<String, String>>> headers;
 
-    public ConnectContentJar(Supplier<ZipFile> zipSupplier, Consumer<Supplier<ZipFile>> closer)
+    public ConnectContentJar(Supplier<ZipFile> zipSupplier, Consumer<Supplier<ZipFile>> closer, Supplier<Optional<Map<String, String>>> headers)
     {
         this.zipSupplier = zipSupplier;
         this.closer = closer;
+        this.headers = headers;
     }
 
     @Override
@@ -93,7 +95,7 @@ public class ConnectContentJar implements ConnectContent
     @Override
     public Optional<Map<String, String>> getHeaders()
     {
-        return Optional.empty();
+        return headers.get();
     }
 
     class JarConnectEntry implements ConnectEntry

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/modules/AtomosModules.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/modules/AtomosModules.java
@@ -469,10 +469,7 @@ public class AtomosModules extends AtomosBase
 
                 generateHeaders(headers, m);
 
-                Optional<Map<String,String>> provided = headerProvider.apply(location, headers);
-
-                headers = new HashMap<>(provided.orElse(headers));
-                holder.setHeaders(Optional.of(headers));
+                headers = applyHeaderProvider(holder, location, headers);
 
                 String symbolicName = headers.get(Constants.BUNDLE_SYMBOLICNAME);
                 if (symbolicName != null)

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/modules/AtomosModules.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/modules/AtomosModules.java
@@ -35,7 +35,6 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -65,7 +64,7 @@ public class AtomosModules extends AtomosBase
     private final Map<Configuration, AtomosLayerBase> byConfig = new HashMap<>();
     private final AtomosLayer bootLayer = createBootLayer();
 
-    public AtomosModules(Map<String, String> config, BiFunction<String, Map<String, String>, Optional<Map<String, String>>> headerProvider)
+    public AtomosModules(Map<String, String> config, HeaderProvider headerProvider)
     {
         super(config, headerProvider);
     }

--- a/atomos/src/main/java/org/apache/felix/atomos/impl/modules/ConnectContentModule.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/modules/ConnectContentModule.java
@@ -16,45 +16,29 @@ package org.apache.felix.atomos.impl.modules;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.lang.module.ModuleDescriptor;
-import java.lang.module.ModuleDescriptor.Provides;
-import java.lang.module.ModuleDescriptor.Requires;
 import java.lang.module.ModuleReader;
 import java.lang.module.ModuleReference;
 import java.net.URI;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.jar.Attributes;
-import java.util.jar.Attributes.Name;
-import java.util.jar.Manifest;
-
-import org.apache.felix.atomos.impl.base.JavaServiceNamespace;
+import java.util.function.Supplier;
 import org.apache.felix.atomos.impl.modules.AtomosModules.AtomosLayerModules;
-import org.osgi.framework.Constants;
-import org.osgi.framework.Version;
 import org.osgi.framework.connect.ConnectContent;
-import org.osgi.framework.namespace.BundleNamespace;
-import org.osgi.resource.Namespace;
 
 public class ConnectContentModule implements ConnectContent
 {
     final Module module;
     final ModuleReference reference;
     final AtomosLayerModules atomosLayer;
-    final String symbolicName;
-    final Version version;
-    final AtomicReference<Optional<Map<String, String>>> headers = new AtomicReference<>();
+    final Supplier<Optional<Map<String, String>>> headers;
     volatile ModuleReader reader = null;
 
-    public ConnectContentModule(Module module, ModuleReference reference, AtomosLayerModules atomosLayer, String symbolicName, Version version)
+    public ConnectContentModule(Module module, ModuleReference reference, AtomosLayerModules atomosLayer, Supplier<Optional<Map<String,String>>> headers)
     {
         this.module = module;
         this.reference = reference;
         this.atomosLayer = atomosLayer;
-        this.symbolicName = symbolicName;
-        this.version = version;
+        this.headers = headers;
     }
 
     @Override
@@ -123,173 +107,8 @@ public class ConnectContentModule implements ConnectContent
     @Override
     public Optional<Map<String, String>> getHeaders()
     {
-        return headers.updateAndGet((h) -> {
-            if (h == null)
-            {
-                h = createManifest();
-            }
-            return h;
-        });
+        return headers.get();
     }
-
-    private Optional<Map<String, String>> createManifest()
-    {
-        return Optional.of(getEntry("META-INF/MANIFEST.MF").map(
-            (mf) -> createManifest(mf)).orElseGet(() -> createManifest(null)));
-
-    }
-
-    private Map<String, String> createManifest(ConnectEntry mfEntry)
-    {
-        Map<String, String> result = new HashMap<>();
-        if (mfEntry != null)
-        {
-            try
-            {
-                Manifest mf = new Manifest(mfEntry.getInputStream());
-                Attributes mainAttrs = mf.getMainAttributes();
-                for (Object key : mainAttrs.keySet())
-                {
-                    Name name = (Name) key;
-                    result.put(name.toString(), mainAttrs.getValue(name));
-                }
-            }
-            catch (IOException e)
-            {
-                throw new UncheckedIOException("Error reading connect manfest.", e);
-            }
-        }
-
-        ModuleDescriptor desc = module.getDescriptor();
-        StringBuilder capabilities = new StringBuilder();
-        StringBuilder requirements = new StringBuilder();
-        String bsn = result.get(Constants.BUNDLE_SYMBOLICNAME);
-        if (bsn == null)
-        {
-            // NOTE that we depend on the framework connect implementation to allow connect bundles
-            // to export java.* packages
-            result.put(Constants.BUNDLE_MANIFESTVERSION, "2");
-            // set the symbolic name for the module; don't allow fragments to attach
-            result.put(Constants.BUNDLE_SYMBOLICNAME,
-                symbolicName + "; " + Constants.FRAGMENT_ATTACHMENT_DIRECTIVE + ":="
-                    + Constants.FRAGMENT_ATTACHMENT_NEVER);
-
-            // set the version
-            result.put(Constants.BUNDLE_VERSION, version.toString());
-
-            // only do exports for non bundle modules
-            // real OSGi bundles already have good export capabilities
-            StringBuilder exportPackageHeader = new StringBuilder();
-            desc.exports().stream().sorted().forEach((exports) ->
-            {
-                if (exportPackageHeader.length() > 0)
-                {
-                    exportPackageHeader.append(", ");
-                }
-                exportPackageHeader.append(exports.source());
-                // TODO map targets to x-friends directive?
-            });
-            if (exportPackageHeader.length() > 0)
-            {
-                result.put(Constants.EXPORT_PACKAGE, exportPackageHeader.toString());
-            }
-
-            // only do requires for non bundle modules
-            // map requires to require bundle
-            StringBuilder requireBundleHeader = new StringBuilder();
-            for (Requires requires : desc.requires())
-            {
-                if (requireBundleHeader.length() > 0)
-                {
-                    requireBundleHeader.append(", ");
-                }
-
-                // before requiring based on the name make sure the required
-                // module has a BSN that is the same
-                String requiresBSN = getRequiresBSN(requires.name());
-                requireBundleHeader.append(requiresBSN).append("; ");
-                // determine the resolution value based on the STATIC modifier
-                String resolution = requires.modifiers().contains(
-                    Requires.Modifier.STATIC) ? Namespace.RESOLUTION_OPTIONAL
-                        : Namespace.RESOLUTION_MANDATORY;
-                requireBundleHeader.append(Constants.RESOLUTION_DIRECTIVE).append(
-                    ":=").append(resolution).append("; ");
-                // determine the visibility value based on the TRANSITIVE modifier
-                String visibility = requires.modifiers().contains(
-                    Requires.Modifier.TRANSITIVE) ? BundleNamespace.VISIBILITY_REEXPORT
-                        : BundleNamespace.VISIBILITY_PRIVATE;
-                requireBundleHeader.append(Constants.VISIBILITY_DIRECTIVE).append(
-                    ":=").append(visibility);
-
-            }
-            if (requireBundleHeader.length() > 0)
-            {
-                result.put(Constants.REQUIRE_BUNDLE, requireBundleHeader.toString());
-            }
-        }
-        else
-        {
-            String origCaps = result.get(Constants.PROVIDE_CAPABILITY);
-            if (origCaps != null)
-            {
-                capabilities.append(origCaps);
-            }
-            String origReqs = result.get(Constants.REQUIRE_CAPABILITY);
-            if (origReqs != null)
-            {
-                requirements.append(origReqs);
-            }
-        }
-        // map provides to a made up namespace only to give proper resolution errors
-        // (although JPMS will likely complain first
-        for (Provides provides : desc.provides())
-        {
-            if (capabilities.length() > 0)
-            {
-                capabilities.append(", ");
-            }
-            capabilities.append(JavaServiceNamespace.JAVA_SERVICE_NAMESPACE).append("; ");
-            capabilities.append(JavaServiceNamespace.JAVA_SERVICE_NAMESPACE).append(
-                "=").append(provides.service()).append("; ");
-            capabilities.append(
-                JavaServiceNamespace.CAPABILITY_PROVIDES_WITH_ATTRIBUTE).append(
-                    "=\"").append(String.join(",", provides.providers())).append("\"");
-        }
-
-        // map uses to a made up namespace only to give proper resolution errors
-        // (although JPMS will likely complain first)
-        for (String uses : desc.uses())
-        {
-            if (requirements.length() > 0)
-            {
-                requirements.append(", ");
-            }
-            requirements.append(JavaServiceNamespace.JAVA_SERVICE_NAMESPACE).append("; ");
-            requirements.append(Constants.RESOLUTION_DIRECTIVE).append(":=").append(
-                Constants.RESOLUTION_OPTIONAL).append("; ");
-            requirements.append(Constants.FILTER_DIRECTIVE).append(":=").append(
-                "\"(").append(JavaServiceNamespace.JAVA_SERVICE_NAMESPACE).append(
-                    "=").append(uses).append(")\"");
-        }
-
-        if (capabilities.length() > 0)
-        {
-            result.put(Constants.PROVIDE_CAPABILITY, capabilities.toString());
-        }
-        if (requirements.length() > 0)
-        {
-            result.put(Constants.REQUIRE_CAPABILITY, requirements.toString());
-        }
-        return result;
-    }
-
-    private String getRequiresBSN(String name)
-    {
-        return module.getLayer().findModule(name).map(
-            m -> atomosLayer.getAtomosContent(m).getSymbolicName()).orElse(name);
-
-    }
-
 
     class ModuleConnectEntry implements ConnectEntry
     {


### PR DESCRIPTION
This is an attempt to provide a hook for a headers provider. The idea is that the provider can change the headers of discovered modules to influence their bundle manifest. It currently is missing tests and is pretty rough around the edges (i.e., needs code cleanup etc). 