### PR TITLE
Fix issues with native build of jaxrs example

### DIFF
--- a/atomos.examples/atomos.examples.jaxrs/pom.xml
+++ b/atomos.examples/atomos.examples.jaxrs/pom.xml
@@ -192,6 +192,7 @@
                             <additionalInitializeAtBuildTime>org.eclipse.jetty.util.log.StdErrLog</additionalInitializeAtBuildTime>
                             <additionalInitializeAtBuildTime>org.eclipse.jetty.util.Uptime</additionalInitializeAtBuildTime>
                             <additionalInitializeAtBuildTime>org.eclipse.jetty.server.HttpOutput</additionalInitializeAtBuildTime>
+                            <additionalInitializeAtBuildTime>org.eclipse.jetty.util.ModuleLocation</additionalInitializeAtBuildTime>
                             <additionalInitializeAtBuildTime>org.slf4j</additionalInitializeAtBuildTime>
                             <additionalInitializeAtBuildTime>org.slf4j.impl</additionalInitializeAtBuildTime>
                             <additionalInitializeAtBuildTime>org.apache.cxf.bus.managers.DestinationFactoryManagerImpl</additionalInitializeAtBuildTime>

--- a/atomos.examples/atomos.examples.jaxrs/reflectAgentConfig.json
+++ b/atomos.examples/atomos.examples.jaxrs/reflectAgentConfig.json
@@ -359,16 +359,6 @@
   "allPublicConstructors":true
 },
 {
-  "name":"org.apache.felix.atomos.impl.base.AtomosCommands"
-},
-{
-  "name":"org.apache.felix.atomos.impl.modules.AtomosModules",
-  "methods":[{"name":"<init>","parameterTypes":["java.util.Map"] }]
-},
-{
-  "name":"org.apache.felix.atomos.Atomos"
-},
-{
   "name":"org.apache.felix.gogo.command.Activator",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },

--- a/atomos.examples/atomos.examples.jaxrs/reflectConfig_felix_atomos.json
+++ b/atomos.examples/atomos.examples.jaxrs/reflectConfig_felix_atomos.json
@@ -1,5 +1,12 @@
 [
    {
+     "name":"org.apache.felix.atomos.impl.modules.AtomosModules",
+     "methods":[{"name":"<init>","parameterTypes":["java.util.Map","org.apache.felix.atomos.Atomos$HeaderProvider"] }]
+   },
+   {
+     "name":"org.apache.felix.atomos.Atomos"
+   },
+   {
     "name" : "org.apache.felix.atomos.impl.base.AtomosCommands",
     "allPublicMethods" : true,
     "allDeclaredMethods" : true,

--- a/atomos.examples/atomos.examples.substrate.maven/reflectConfig_felix_atomos.json
+++ b/atomos.examples/atomos.examples.substrate.maven/reflectConfig_felix_atomos.json
@@ -1,5 +1,12 @@
 [
    {
+     "name":"org.apache.felix.atomos.impl.modules.AtomosModules",
+     "methods":[{"name":"<init>","parameterTypes":["java.util.Map","org.apache.felix.atomos.Atomos$HeaderProvider"] }]
+   },
+   {
+     "name":"org.apache.felix.atomos.Atomos"
+   },
+   {
     "name" : "org.apache.felix.atomos.impl.base.AtomosCommands",
     "allPublicMethods" : true,
     "allDeclaredMethods" : true,

--- a/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/finaliser/ni/NativeImagePlugin.java
+++ b/atomos.utils/atomos.utils.core/src/main/java/org/apache/felix/atomos/utils/core/plugins/finaliser/ni/NativeImagePlugin.java
@@ -115,7 +115,7 @@ public class NativeImagePlugin implements FinalPlugin<NativeImageBuilderConfig>
                 config.nativeImageExecutable());
 
             //execute build an native image
-            nOptional.ifPresent(cli -> {
+            nOptional.ifPresentOrElse(cli -> {
                 try
                 {
                     Path binFile = cli.execute(binDir, arguments);
@@ -125,12 +125,17 @@ public class NativeImagePlugin implements FinalPlugin<NativeImageBuilderConfig>
                 {
                     throw new RuntimeException(e);
                 }
-            });
+            }, () -> {throw new RuntimeException("Missing native image executable. Set 'GRAALVM_HOME' with the path as an environment variable");});
 
         }
         catch (Exception e)
         {
-            e.printStackTrace();
+            if (e instanceof RuntimeException) {
+            	throw (RuntimeException) e;
+            }
+            else {
+            	throw new RuntimeException(e);
+            }
         }
     }
 

--- a/atomos.utils/atomos.utils.substrate.impl/src/main/java/org/apache/felix/atomos/utils/substrate/impl/NativeImageCliUtil.java
+++ b/atomos.utils/atomos.utils.substrate.impl/src/main/java/org/apache/felix/atomos/utils/substrate/impl/NativeImageCliUtil.java
@@ -30,7 +30,7 @@ import org.apache.felix.atomos.utils.substrate.api.NativeImageArguments;
 public class NativeImageCliUtil
 {
 
-    private static final String GRAAL_HOME = "GRAAL_HOME";
+    public static final String GRAALVM_HOME = "GRAALVM_HOME";
 
     private static final String JAVA_HOME = "java.home";
 
@@ -48,7 +48,7 @@ public class NativeImageCliUtil
 
         if (exec.isEmpty())
         {
-            throw new Exception("Missing native image executable. Set '" + GRAAL_HOME
+            throw new Exception("Missing native image executable. Set '" + GRAALVM_HOME
                 + "' with the path as an environment variable");
         }
 
@@ -96,9 +96,9 @@ public class NativeImageCliUtil
             {
                 return oExec;
             }
-            if (System.getenv(GRAAL_HOME) != null)
+            if (System.getenv(GRAALVM_HOME) != null)
             {
-                oExec = findNativeImageExecutable(Paths.get(System.getenv(GRAAL_HOME)));
+                oExec = findNativeImageExecutable(Paths.get(System.getenv(GRAALVM_HOME)));
                 if (oExec.isPresent())
                 {
                     return oExec;


### PR DESCRIPTION
There were some issues with building jaxrs native image example.

`org.eclipse.jetty.util.ModuleLocation` needed to be configured for initialize at build time

I also updated the atomos maven plugin to fail if it could not find the `native-image` executable.  We now read the GRAALVM_HOME environment variable like the `org.graalvm.buildtools:native-maven-plugin` does to be consistent.