### PR TITLE
Issue 60 - correctly delegate to platform for modules with no class loader

### DIFF
--- a/atomos/src/main/java/org/apache/felix/atomos/impl/modules/ConnectContentModule.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/modules/ConnectContentModule.java
@@ -27,6 +27,7 @@ import org.osgi.framework.connect.ConnectContent;
 
 public class ConnectContentModule implements ConnectContent
 {
+	static final ClassLoader platformLoader = ClassLoader.getPlatformClassLoader();
     final Module module;
     final ModuleReference reference;
     final AtomosLayerModules atomosLayer;
@@ -61,7 +62,7 @@ public class ConnectContentModule implements ConnectContent
     @Override
     public Optional<ClassLoader> getClassLoader()
     {
-        return Optional.ofNullable(module.getClassLoader());
+        return Optional.ofNullable(module.getClassLoader()).or(() -> Optional.of(ConnectContentModule.platformLoader));
     }
 
     @Override


### PR DESCRIPTION
Fixes #60

This is only the possible fix.  I would appreciate if someone could look at providing a testcase in the `org.apache.felix.atomos.tests.modulepath.service.ModulepathLaunchTest` test to cover this.  It will be some time before I can focus on creating a test there.