### PR TITLE
Don't add parent packages, only the ones that are actually present

### DIFF
--- a/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosBase.java
+++ b/atomos/src/main/java/org/apache/felix/atomos/impl/base/AtomosBase.java
@@ -1663,9 +1663,8 @@ public abstract class AtomosBase implements Atomos, SynchronousBundleListener, F
                 try
                 {
                     content.getEntries().forEach((s) -> {
-                        if (s.length() > 1 && s.endsWith("/") && s.indexOf('-') < 0)
-                        {
-                            String pkg = s.substring(0, s.length() - 1).replace('/', '.');
+                        if (s.endsWith(".class")) {
+                            String pkg = s.substring(0, s.lastIndexOf('/')).replace('/', '.');
                             packageToAtomosContent.put(pkg,
                                 (AtomosContentIndexed) atomosContent);
                         }


### PR DESCRIPTION
Previously the code added all the packages, also packages which were just found as parent directories in the Jar file. As packages aren't hierarchical this isn't correct. Only packages in which .class files are found should be added.